### PR TITLE
Add simple blog routing

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,33 @@
+import { blogPosts } from '@/lib/blogData';
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function BlogPostPage({ params }: any) {
+  const post = blogPosts.find(p => p.slug === params.slug);
+  if (!post) return notFound();
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-12 grid md:grid-cols-4 gap-8">
+      <aside className="md:col-span-1 order-last md:order-first">
+        <h2 className="text-lg font-semibold mb-4">More Posts</h2>
+        <ul className="space-y-2 text-sm">
+          {blogPosts.map(p => (
+            <li key={p.slug}>
+              <Link href={`/blog/${p.slug}`} className="text-peach hover:underline">
+                {p.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <article className="md:col-span-3">
+        <Image src={post.image} alt="" width={800} height={400} className="w-full h-60 object-cover rounded-md mb-6" />
+        <h1 className="text-3xl font-bold mb-2">{post.title}</h1>
+        <p className="text-sm text-gray-600 mb-6">{post.date}</p>
+        <div className="prose" dangerouslySetInnerHTML={{ __html: post.content.replace(/\n/g, '<br/>') }} />
+      </article>
+    </div>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { blogPosts } from '@/lib/blogData';
+
+export default function BlogIndex() {
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-12">
+      <h1 className="text-3xl font-semibold mb-6">Blog</h1>
+      <ul className="grid gap-8 md:grid-cols-2">
+        {blogPosts.map(post => (
+          <li key={post.slug} className="bg-white rounded-lg shadow-md overflow-hidden">
+            <Link href={`/blog/${post.slug}`} className="block hover:bg-gray-50">
+              <Image src={post.image} alt="" width={600} height={300} className="w-full h-40 object-cover" />
+              <div className="p-4">
+                <h2 className="text-xl font-medium mb-2">{post.title}</h2>
+                <p className="text-sm text-gray-600">{post.excerpt}</p>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ export default function Home() {
         <nav className="space-x-6 text-[#F4A261] text-sm font-medium">
           <Link href="/projects">Projects</Link>
           <Link href="/about">About</Link>
+          <Link href="/blog">Blog</Link>
           <Link href="/contact">Contact</Link>
         </nav>
       </header>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,6 +9,7 @@ export default function Header() {
           <Link href="/">Home</Link>
           <Link href="/about">About</Link>
           <Link href="/projects">Projects</Link>
+          <Link href="/blog">Blog</Link>
           <Link href="/contact">Contact</Link>
         </div>
       </nav>

--- a/src/lib/blogData.ts
+++ b/src/lib/blogData.ts
@@ -1,0 +1,31 @@
+export interface BlogPost {
+  slug: string;
+  title: string;
+  date: string;
+  excerpt: string;
+  content: string;
+  image: string;
+}
+
+export const blogPosts: BlogPost[] = [
+  {
+    slug: 'first-post',
+    title: 'Finding Play in Everyday Life',
+    date: '2025-01-15',
+    excerpt: 'Tips for rediscovering moments of wonder in your daily routine.',
+    content: `## Welcome
+
+This is the first mock blog post. Here you can add markdown style content and explore ideas about playful design.`,
+    image: '/assets/tagline.svg',
+  },
+  {
+    slug: 'second-post',
+    title: 'Designing for Curiosity',
+    date: '2025-02-20',
+    excerpt: 'How to craft experiences that invite exploration and collaboration.',
+    content: `## Another Post
+
+More mock content goes here. Imagine engaging stories about immersive games and interactive art installations.`,
+    image: '/assets/next.svg',
+  },
+];


### PR DESCRIPTION
## Summary
- add `blogData.ts` with sample posts
- create blog index that links to each post
- implement dynamic `[slug]` page with sidebar and featured image

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687798bc69288320bdde14a1265b5f96