### PR TITLE
Fix dev setup docs

### DIFF
--- a/DEV SETUP.md
+++ b/DEV SETUP.md
@@ -5,13 +5,13 @@
 ```bash
 git clone <your-repo-url>
 cd play-compass
-pnpm install
+npm install
 ```
 
 ## ▶️ 2. Run the Dev Server
 
 ```bash
-pnpm dev
+npm run dev
 ```
 
 If you see styling issues:


### PR DESCRIPTION
## Summary
- switch setup docs to npm instead of pnpm

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877a493d79c832083f7b8c1d9eeeb07