### PR TITLE
Finalize MDX blog system

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to Play Compass Blog
+
+Blog posts live under `src/app/blog` as MDX files. Each post should include this YAML front matter:
+
+```yaml
+title: "Your Post Title"
+date: "YYYY-MM-DD"
+excerpt: "A short teaser for list pages."
+tags: [tag1, tag2]
+category: CategoryName
+featured: false # optional
+image: "/assets/optional-image.png" # optional
+```
+
+File names become the URL slug (`my-post.mdx` → `/blog/my-post`). Keep slugs short and descriptive using hyphens.
+
+Use regular Markdown along with React components exported in `src/mdx-components.tsx`. Example:
+
+```mdx
+import VideoEmbed from '@/components/mdx/VideoEmbed'
+
+<VideoEmbed src="https://example.com/embed/video" />
+```
+
+Run the following before committing new posts:
+
+```bash
+npm run lint
+npm test
+npm run build
+```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Rich components like `<VideoEmbed />` and `<NewsletterForm />` can be used insid
 
 To add a new post, create `your-post.mdx` with the front matter above and write Markdown/MDX content.
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed blog guidelines.
+
 ## Testing
 
 Run lint, tests and build before committing:

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,3 +1,19 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'About | Play Compass',
+  description: 'Learn about the playful philosophy behind Play Compass.',
+  openGraph: {
+    title: 'About | Play Compass',
+    description: 'Learn about the playful philosophy behind Play Compass.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'About | Play Compass',
+    description: 'Learn about the playful philosophy behind Play Compass.',
+  },
+};
+
 export default function AboutPage() {
   return (
     <div className="max-w-5xl mx-auto px-4 py-12">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,12 +2,35 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getAllPosts, getPost } from '@/lib/getPosts';
+import type { Metadata } from 'next';
 
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
   const posts = await getAllPosts();
   return posts.map(p => ({ slug: p.slug }));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function generateMetadata({ params }: any): Promise<Metadata> {
+  const post = await getPost(params.slug);
+  if (!post) return {};
+  return {
+    title: `${post.meta.title} | Play Compass`,
+    description: post.meta.excerpt,
+    openGraph: {
+      title: post.meta.title,
+      description: post.meta.excerpt,
+      type: 'article',
+      images: post.meta.image ? [post.meta.image] : undefined,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.meta.title,
+      description: post.meta.excerpt,
+      images: post.meta.image ? [post.meta.image] : undefined,
+    },
+  };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -18,21 +41,37 @@ export default async function BlogPostPage({ params }: any) {
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-12 grid md:grid-cols-4 gap-8">
-      <aside className="md:col-span-1 order-last md:order-first">
-        <h2 className="text-lg font-semibold mb-4">More Posts</h2>
-        <ul className="space-y-2 text-sm">
-          {allPosts.map(p => (
-            <li key={p.slug}>
-              <Link href={`/blog/${p.slug}`} className="text-peach hover:underline">
-                {p.title}
-              </Link>
-            </li>
-          ))}
-        </ul>
+      <aside className="md:col-span-1 order-last md:order-first space-y-8">
+        {post.toc.length > 0 && (
+          <nav>
+            <h2 className="text-lg font-semibold mb-4">On this page</h2>
+            <ul className="space-y-2 text-sm">
+              {post.toc.map(item => (
+                <li key={item.id}>
+                  <a href={`#${item.id}`} className="text-peachDark hover:underline">
+                    {item.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
+        <div>
+          <h2 className="text-lg font-semibold mb-4">More Posts</h2>
+          <ul className="space-y-2 text-sm">
+            {allPosts.map(p => (
+              <li key={p.slug}>
+                <Link href={`/blog/${p.slug}`} className="text-peachDark hover:underline">
+                  {p.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
       </aside>
       <article className="md:col-span-3">
         {post.meta.image && (
-          <Image src={post.meta.image} alt="" width={800} height={400} className="w-full h-60 object-cover rounded-md mb-6" />
+          <Image src={post.meta.image} alt={post.meta.title} width={800} height={400} className="w-full h-60 object-cover rounded-md mb-6" />
         )}
         <h1 className="text-3xl font-bold mb-2">{post.meta.title}</h1>
         <p className="text-sm text-gray-600 mb-6">{post.meta.date}</p>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,24 +1,65 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { getAllPosts } from '@/lib/getPosts';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Blog | Play Compass',
+  description: 'Thoughts on play, puzzles and interactive experiences.',
+  openGraph: {
+    title: 'Blog | Play Compass',
+    description: 'Thoughts on play, puzzles and interactive experiences.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Blog | Play Compass',
+    description: 'Thoughts on play, puzzles and interactive experiences.',
+  },
+};
 
 export const dynamic = 'force-static';
 
 export default async function BlogIndex() {
   const posts = await getAllPosts();
+  const featured = posts.filter(p => p.featured);
+  const others = posts.filter(p => !p.featured);
   return (
     <div className="max-w-5xl mx-auto px-4 py-12">
       <h1 className="text-3xl font-semibold mb-6">Blog</h1>
+      {featured.length > 0 && (
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-4">Featured</h2>
+          <ul className="grid gap-8 md:grid-cols-2">
+            {featured.map(post => (
+              <li key={post.slug} className="bg-white rounded-lg shadow-md overflow-hidden">
+                <Link href={`/blog/${post.slug}`} className="block hover:bg-gray-50">
+                  {post.image && (
+                    <Image src={post.image} alt={post.title} width={600} height={300} className="w-full h-40 object-cover" />
+                  )}
+                  <div className="p-4">
+                    <h3 className="text-xl font-medium mb-2">{post.title}</h3>
+                    <p className="text-sm text-gray-600 mb-2">{post.date}</p>
+                    <p className="text-sm text-gray-700 mb-4">{post.excerpt}</p>
+                    <span className="text-peachDark font-medium">Read more →</span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
       <ul className="grid gap-8 md:grid-cols-2">
-        {posts.map(post => (
+        {others.map(post => (
           <li key={post.slug} className="bg-white rounded-lg shadow-md overflow-hidden">
             <Link href={`/blog/${post.slug}`} className="block hover:bg-gray-50">
               {post.image && (
-                <Image src={post.image} alt="" width={600} height={300} className="w-full h-40 object-cover" />
+                <Image src={post.image} alt={post.title} width={600} height={300} className="w-full h-40 object-cover" />
               )}
               <div className="p-4">
-                <h2 className="text-xl font-medium mb-2">{post.title}</h2>
-                <p className="text-sm text-gray-600">{post.excerpt}</p>
+                <h3 className="text-xl font-medium mb-1">{post.title}</h3>
+                <p className="text-sm text-gray-600 mb-2">{post.date}</p>
+                <p className="text-sm text-gray-700 mb-4">{post.excerpt}</p>
+                <span className="text-peachDark font-medium">Read more →</span>
               </div>
             </Link>
           </li>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,26 @@
 // src/app/page.tsx
 import Link from 'next/link';
 import Image from 'next/image';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Play Compass - games and puzzles for curious adults',
+  description:
+    'Discover puzzles, playgrounds and playful adventures designed for curious adults.',
+  openGraph: {
+    title: 'Play Compass',
+    description:
+      'Discover puzzles, playgrounds and playful adventures designed for curious adults.',
+    images: ['/assets/logo.svg'],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Play Compass',
+    description:
+      'Discover puzzles, playgrounds and playful adventures designed for curious adults.',
+    images: ['/assets/logo.svg'],
+  },
+};
 
 export default function Home() {
   return (
@@ -15,12 +35,15 @@ export default function Home() {
           className="w-48 md:w-60 mb-6 animate-float"
           priority
         />
-        <h1 className="text-4xl md:text-5xl font-bold text-peach max-w-xl">
+        <h1 className="text-5xl md:text-6xl font-bold text-peachDark max-w-xl animate-fadeIn">
           Helping grown-ups find their way back to wonder
         </h1>
+        <p className="mt-4 text-lg md:text-xl max-w-xl animate-fadeIn">
+          Discover puzzles, playgrounds, and playful adventures designed for curious adults. Navigate your next experience with purpose—and a wink.
+        </p>
         <Image
           src="/assets/dotted-arrow.svg"
-          alt=""
+          alt="dotted arrow decoration"
           width={150}
           height={80}
           className="absolute bottom-0 right-4 w-24 md:w-32 animate-bounce"

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,3 +1,19 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Projects | Play Compass',
+  description: 'A sampling of playful projects and experiments from Play Compass.',
+  openGraph: {
+    title: 'Projects | Play Compass',
+    description: 'A sampling of playful projects and experiments from Play Compass.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Projects | Play Compass',
+    description: 'A sampling of playful projects and experiments from Play Compass.',
+  },
+};
+
 export default function ProjectsPage() {
   return (
     <div className="max-w-5xl mx-auto px-4 py-12">

--- a/src/lib/__tests__/getPosts.test.ts
+++ b/src/lib/__tests__/getPosts.test.ts
@@ -18,5 +18,6 @@ describe('MDX posts loader', () => {
     const post = await getPost(posts[0].slug);
     expect(post.slug).toBe(posts[0].slug);
     expect(post.content).toBeTruthy();
+    expect(Array.isArray(post.toc)).toBe(true);
   });
 });

--- a/src/lib/getPosts.ts
+++ b/src/lib/getPosts.ts
@@ -20,6 +20,7 @@ export interface Post {
   slug: string;
   meta: PostMeta;
   content: React.ReactElement;
+  toc: { id: string; title: string }[];
 }
 
 const POSTS_PATH = path.join(process.cwd(), 'src/app/blog');
@@ -43,6 +44,12 @@ export async function getPost(slug: string): Promise<Post> {
   const filepath = path.join(POSTS_PATH, `${slug}.mdx`);
   const source = await fs.readFile(filepath, 'utf8');
 
+  const toc = Array.from(source.matchAll(/^##\s+(.*)$/gm)).map(m => {
+    const title = m[1].trim();
+    const id = title.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    return { id, title };
+  });
+
   const { content, frontmatter } = await compileMDX<PostMeta>({
     source,
     options: {
@@ -56,5 +63,6 @@ export async function getPost(slug: string): Promise<Post> {
     slug,
     meta: frontmatter,
     content,
+    toc,
   };
 }

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -1,11 +1,19 @@
 import VideoEmbed from './components/mdx/VideoEmbed';
 import NewsletterForm from './components/mdx/NewsletterForm';
 import type { MDXComponents } from 'mdx/types';
+import React from 'react';
+
+function H2(props: React.HTMLAttributes<HTMLHeadingElement>) {
+  const text = typeof props.children === 'string' ? props.children : '';
+  const id = text.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  return <h2 id={id} {...props} />;
+}
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     VideoEmbed,
     NewsletterForm,
+    h2: H2,
     ...components,
   };
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ const config = {
         cream: '#FFFCF4',
         forest: '#508072',
         peach: '#F4A261',
+        peachDark: '#9c4a21',
       },
       fontFamily: {
         sans: ['ui-sans-serif', 'system-ui', 'sans-serif'],
@@ -21,9 +22,14 @@ const config = {
           '0%, 100%': { transform: 'translateY(0)' },
           '50%': { transform: 'translateY(-8px)' },
         },
+        fadeIn: {
+          from: { opacity: 0 },
+          to: { opacity: 1 },
+        },
       },
       animation: {
         float: 'float 4s ease-in-out infinite',
+        fadeIn: 'fadeIn 2s ease-in-out',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add CONTRIBUTING with MDX blogging rules
- link to CONTRIBUTING from README
- tweak Tailwind theme (peachDark + fadeIn)
- add SEO metadata and hero subheading on home page
- add metadata on about, projects and blog pages
- separate featured posts and add excerpts on blog index
- generate per-post metadata and TOC on blog posts
- add heading anchor support for MDX

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877c5c0cf648320aca7667c228cbe09