### PR TITLE
Finalize MDX blog and polish site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to the Play Compass Blog
+
+Blog posts live in `src/app/blog` as `.mdx` files. Each filename becomes the URL slug. Use the following front matter template:
+
+```mdx
+---
+title: "Your Post Title"
+date: "YYYY-MM-DD"
+excerpt: "Short summary used in listings"
+tags: [tag1, tag2]
+category: Category
+featured: false
+image: "/assets/optional-image.png"
+---
+```
+
+Write content in Markdown and embed React components exported from `src/mdx-components.tsx` as needed. Images should reside under `public/assets` and referenced with `/assets/your-image.png`.
+
+To preview locally run `npm run dev`. Before opening a pull request, execute:
+
+```bash
+npm run lint
+npm test
+npm run build
+```
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Rich components like `<VideoEmbed />` and `<NewsletterForm />` can be used insid
 
 To add a new post, create `your-post.mdx` with the front matter above and write Markdown/MDX content.
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed blog-writing guidelines.
+
 ## Testing
 
 Run lint, tests and build before committing:

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -8,6 +8,6 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
   },
-  transformIgnorePatterns: ['/node_modules/(?!(next-mdx-remote)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(next-mdx-remote|rehype-slug)/)'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts']
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "next": "15.4.1",
         "next-mdx-remote": "^5.0.0",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "rehype-slug": "^6.0.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -8314,6 +8315,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -8562,6 +8569,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-estree": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
@@ -8611,6 +8631,19 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -13169,6 +13202,23 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next": "15.4.1",
     "next-mdx-remote": "^5.0.0",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "rehype-slug": "^6.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'About | Play Compass',
+  description: 'Learn about Play Compass and our mission to create playful experiences for adults.',
+};
+
 export default function AboutPage() {
   return (
     <div className="max-w-5xl mx-auto px-4 py-12">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
 import { getAllPosts, getPost } from '@/lib/getPosts';
 
 export const dynamicParams = false;
@@ -11,10 +12,37 @@ export async function generateStaticParams() {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function generateMetadata({ params }: any): Promise<Metadata> {
+  const post = await getPost(params.slug);
+  if (!post) return {};
+  const { title, excerpt, image } = post.meta;
+  const url = `https://play-compass.vercel.app/blog/${post.slug}`;
+  return {
+    title: `${title} | Play Compass`,
+    description: excerpt,
+    openGraph: {
+      title,
+      description: excerpt,
+      type: 'article',
+      url,
+      images: image ? [{ url: image }] : undefined,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description: excerpt,
+      images: image ? [image] : undefined,
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function BlogPostPage({ params }: any) {
   const post = await getPost(params.slug);
   if (!post) return notFound();
   const allPosts = await getAllPosts();
+
+  const author = 'Jennifer Walker';
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-12 grid md:grid-cols-4 gap-8">
@@ -32,10 +60,26 @@ export default async function BlogPostPage({ params }: any) {
       </aside>
       <article className="md:col-span-3">
         {post.meta.image && (
-          <Image src={post.meta.image} alt="" width={800} height={400} className="w-full h-60 object-cover rounded-md mb-6" />
+          <Image src={post.meta.image} alt={post.meta.title} width={800} height={400} className="w-full h-60 object-cover rounded-md mb-6" />
         )}
         <h1 className="text-3xl font-bold mb-2">{post.meta.title}</h1>
-        <p className="text-sm text-gray-600 mb-6">{post.meta.date}</p>
+        <p className="text-sm text-gray-600 mb-6">By {author} • {post.meta.date}</p>
+
+        {post.headings.length > 0 && (
+          <nav className="mb-6 border-l-4 border-peach pl-4">
+            <p className="font-medium mb-2">On this page</p>
+            <ul className="space-y-1 text-sm">
+              {post.headings.map(h => (
+                <li key={h.id}>
+                  <a href={`#${h.id}`} className="text-peach hover:underline">
+                    {h.text}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
+
         <div className="prose">
           {post.content}
         </div>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,24 +1,56 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import { Metadata } from 'next';
 import { getAllPosts } from '@/lib/getPosts';
+
+export const metadata: Metadata = {
+  title: 'Blog | Play Compass',
+  description: 'Articles and updates from the Play Compass playground.',
+};
 
 export const dynamic = 'force-static';
 
 export default async function BlogIndex() {
   const posts = await getAllPosts();
+  const featured = posts.filter(p => p.featured);
+  const regular = posts.filter(p => !p.featured);
   return (
     <div className="max-w-5xl mx-auto px-4 py-12">
       <h1 className="text-3xl font-semibold mb-6">Blog</h1>
+      {featured.length > 0 && (
+        <section className="mb-12">
+          <h2 className="text-2xl font-semibold mb-4">Featured</h2>
+          <ul className="grid gap-8 md:grid-cols-2">
+            {featured.map(post => (
+              <li key={post.slug} className="bg-white rounded-lg shadow-md overflow-hidden">
+                <Link href={`/blog/${post.slug}`} className="block hover:bg-gray-50">
+                  {post.image && (
+                    <Image src={post.image} alt={post.title} width={600} height={300} className="w-full h-40 object-cover" />
+                  )}
+                  <div className="p-4">
+                    <h3 className="text-xl font-medium mb-2">{post.title}</h3>
+                    <p className="text-sm text-gray-600 mb-2">{post.date}</p>
+                    <p className="text-sm text-gray-600">{post.excerpt}</p>
+                    <span className="text-peach block mt-2">Read more →</span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
       <ul className="grid gap-8 md:grid-cols-2">
-        {posts.map(post => (
+        {regular.map(post => (
           <li key={post.slug} className="bg-white rounded-lg shadow-md overflow-hidden">
             <Link href={`/blog/${post.slug}`} className="block hover:bg-gray-50">
               {post.image && (
-                <Image src={post.image} alt="" width={600} height={300} className="w-full h-40 object-cover" />
+                <Image src={post.image} alt={post.title} width={600} height={300} className="w-full h-40 object-cover" />
               )}
               <div className="p-4">
-                <h2 className="text-xl font-medium mb-2">{post.title}</h2>
+                <h3 className="text-xl font-medium mb-2">{post.title}</h3>
+                <p className="text-sm text-gray-600 mb-2">{post.date}</p>
                 <p className="text-sm text-gray-600">{post.excerpt}</p>
+                <span className="text-peach block mt-2">Read more →</span>
               </div>
             </Link>
           </li>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,16 @@
 // src/app/page.tsx
 import Link from 'next/link';
 import Image from 'next/image';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Play Compass',
+  description: 'Helping grown-ups find their way back to wonder with playful games and experiences.',
+  openGraph: {
+    title: 'Play Compass',
+    description: 'Helping grown-ups find their way back to wonder with playful games and experiences.',
+  },
+};
 
 export default function Home() {
   return (
@@ -15,12 +25,15 @@ export default function Home() {
           className="w-48 md:w-60 mb-6 animate-float"
           priority
         />
-        <h1 className="text-4xl md:text-5xl font-bold text-peach max-w-xl">
+        <h1 className="text-5xl md:text-6xl font-bold text-peach max-w-xl animate-fadeInUp">
           Helping grown-ups find their way back to wonder
         </h1>
+        <p className="mt-4 text-lg md:text-xl max-w-md animate-fadeInUp">
+          Discover puzzles, playgrounds, and playful adventures designed for curious adults. Navigate your next experience with purpose—and a wink.
+        </p>
         <Image
           src="/assets/dotted-arrow.svg"
-          alt=""
+          alt="Decorative dotted arrow"
           width={150}
           height={80}
           className="absolute bottom-0 right-4 w-24 md:w-32 animate-bounce"

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Projects | Play Compass',
+  description: 'Explore selected playful projects created by Play Compass.',
+};
+
 export default function ProjectsPage() {
   return (
     <div className="max-w-5xl mx-auto px-4 py-12">

--- a/src/lib/__tests__/getPosts.test.ts
+++ b/src/lib/__tests__/getPosts.test.ts
@@ -4,6 +4,7 @@ jest.mock('next-mdx-remote/rsc', () => ({
 jest.mock('@/mdx-components', () => ({
   useMDXComponents: () => ({})
 }));
+jest.mock('rehype-slug', () => () => {});
 
 import { getAllPosts, getPost } from '../getPosts';
 
@@ -18,5 +19,6 @@ describe('MDX posts loader', () => {
     const post = await getPost(posts[0].slug);
     expect(post.slug).toBe(posts[0].slug);
     expect(post.content).toBeTruthy();
+    expect(Array.isArray(post.headings)).toBe(true);
   });
 });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,9 +21,14 @@ const config = {
           '0%, 100%': { transform: 'translateY(0)' },
           '50%': { transform: 'translateY(-8px)' },
         },
+        fadeInUp: {
+          '0%': { opacity: '0', transform: 'translateY(10px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
       },
       animation: {
         float: 'float 4s ease-in-out infinite',
+        fadeInUp: 'fadeInUp 0.6s ease-out both',
       },
     },
   },


### PR DESCRIPTION
## Summary
- finalize MDX blog loader with heading support and rehype-slug
- display featured posts and metadata on `/blog`
- add TOC, author line and SEO metadata for blog posts
- improve homepage hero with animation and subheading
- provide per-page metadata for SEO
- add contributing guide for writing blog posts
- create fade-in animation in Tailwind config
- update tests for new blog loader behaviour

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877c5c0cf648320aca7667c228cbe09